### PR TITLE
[Pool Metadata] creates search pool button and form

### DIFF
--- a/packages/balancer-gql/src/gql/__generated__/arbitrum.ts
+++ b/packages/balancer-gql/src/gql/__generated__/arbitrum.ts
@@ -5232,6 +5232,13 @@ export type PoolOwnerQueryVariables = Exact<{
 
 export type PoolOwnerQuery = { __typename?: 'Query', pool?: { __typename?: 'Pool', owner?: any | null } | null };
 
+export type PoolAddressQueryVariables = Exact<{
+  poolId: Scalars['ID'];
+}>;
+
+
+export type PoolAddressQuery = { __typename?: 'Query', pool?: { __typename?: 'Pool', address: any } | null };
+
 
 export const PoolsDocument = gql`
     query Pools($owner: Bytes!) {
@@ -5261,6 +5268,13 @@ export const PoolOwnerDocument = gql`
   }
 }
     `;
+export const PoolAddressDocument = gql`
+    query PoolAddress($poolId: ID!) {
+  pool(id: $poolId) {
+    address
+  }
+}
+    `;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 
@@ -5277,6 +5291,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     PoolOwner(variables: PoolOwnerQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<PoolOwnerQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<PoolOwnerQuery>(PoolOwnerDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'PoolOwner', 'query');
+    },
+    PoolAddress(variables: PoolAddressQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<PoolAddressQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PoolAddressQuery>(PoolAddressDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'PoolAddress', 'query');
     }
   };
 }
@@ -5294,6 +5311,9 @@ export function getSdkWithHooks(client: GraphQLClient, withWrapper: SdkFunctionW
     },
     usePoolOwner(variables: PoolOwnerQueryVariables, config?: SWRConfigInterface<PoolOwnerQuery, ClientError>) {
       return useSWR<PoolOwnerQuery, ClientError>(genKey<PoolOwnerQueryVariables>('PoolOwner', variables), () => sdk.PoolOwner(variables), config);
+    },
+    usePoolAddress(variables: PoolAddressQueryVariables, config?: SWRConfigInterface<PoolAddressQuery, ClientError>) {
+      return useSWR<PoolAddressQuery, ClientError>(genKey<PoolAddressQueryVariables>('PoolAddress', variables), () => sdk.PoolAddress(variables), config);
     }
   };
 }

--- a/packages/balancer-gql/src/gql/__generated__/goerli.ts
+++ b/packages/balancer-gql/src/gql/__generated__/goerli.ts
@@ -5232,6 +5232,13 @@ export type PoolOwnerQueryVariables = Exact<{
 
 export type PoolOwnerQuery = { __typename?: 'Query', pool?: { __typename?: 'Pool', owner?: any | null } | null };
 
+export type PoolAddressQueryVariables = Exact<{
+  poolId: Scalars['ID'];
+}>;
+
+
+export type PoolAddressQuery = { __typename?: 'Query', pool?: { __typename?: 'Pool', address: any } | null };
+
 
 export const PoolsDocument = gql`
     query Pools($owner: Bytes!) {
@@ -5261,6 +5268,13 @@ export const PoolOwnerDocument = gql`
   }
 }
     `;
+export const PoolAddressDocument = gql`
+    query PoolAddress($poolId: ID!) {
+  pool(id: $poolId) {
+    address
+  }
+}
+    `;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 
@@ -5277,6 +5291,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     PoolOwner(variables: PoolOwnerQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<PoolOwnerQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<PoolOwnerQuery>(PoolOwnerDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'PoolOwner', 'query');
+    },
+    PoolAddress(variables: PoolAddressQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<PoolAddressQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PoolAddressQuery>(PoolAddressDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'PoolAddress', 'query');
     }
   };
 }
@@ -5294,6 +5311,9 @@ export function getSdkWithHooks(client: GraphQLClient, withWrapper: SdkFunctionW
     },
     usePoolOwner(variables: PoolOwnerQueryVariables, config?: SWRConfigInterface<PoolOwnerQuery, ClientError>) {
       return useSWR<PoolOwnerQuery, ClientError>(genKey<PoolOwnerQueryVariables>('PoolOwner', variables), () => sdk.PoolOwner(variables), config);
+    },
+    usePoolAddress(variables: PoolAddressQueryVariables, config?: SWRConfigInterface<PoolAddressQuery, ClientError>) {
+      return useSWR<PoolAddressQuery, ClientError>(genKey<PoolAddressQueryVariables>('PoolAddress', variables), () => sdk.PoolAddress(variables), config);
     }
   };
 }

--- a/packages/balancer-gql/src/gql/__generated__/mainnet.ts
+++ b/packages/balancer-gql/src/gql/__generated__/mainnet.ts
@@ -5232,6 +5232,13 @@ export type PoolOwnerQueryVariables = Exact<{
 
 export type PoolOwnerQuery = { __typename?: 'Query', pool?: { __typename?: 'Pool', owner?: any | null } | null };
 
+export type PoolAddressQueryVariables = Exact<{
+  poolId: Scalars['ID'];
+}>;
+
+
+export type PoolAddressQuery = { __typename?: 'Query', pool?: { __typename?: 'Pool', address: any } | null };
+
 
 export const PoolsDocument = gql`
     query Pools($owner: Bytes!) {
@@ -5261,6 +5268,13 @@ export const PoolOwnerDocument = gql`
   }
 }
     `;
+export const PoolAddressDocument = gql`
+    query PoolAddress($poolId: ID!) {
+  pool(id: $poolId) {
+    address
+  }
+}
+    `;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 
@@ -5277,6 +5291,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     PoolOwner(variables: PoolOwnerQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<PoolOwnerQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<PoolOwnerQuery>(PoolOwnerDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'PoolOwner', 'query');
+    },
+    PoolAddress(variables: PoolAddressQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<PoolAddressQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PoolAddressQuery>(PoolAddressDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'PoolAddress', 'query');
     }
   };
 }
@@ -5294,6 +5311,9 @@ export function getSdkWithHooks(client: GraphQLClient, withWrapper: SdkFunctionW
     },
     usePoolOwner(variables: PoolOwnerQueryVariables, config?: SWRConfigInterface<PoolOwnerQuery, ClientError>) {
       return useSWR<PoolOwnerQuery, ClientError>(genKey<PoolOwnerQueryVariables>('PoolOwner', variables), () => sdk.PoolOwner(variables), config);
+    },
+    usePoolAddress(variables: PoolAddressQueryVariables, config?: SWRConfigInterface<PoolAddressQuery, ClientError>) {
+      return useSWR<PoolAddressQuery, ClientError>(genKey<PoolAddressQueryVariables>('PoolAddress', variables), () => sdk.PoolAddress(variables), config);
     }
   };
 }

--- a/packages/balancer-gql/src/gql/__generated__/polygon.ts
+++ b/packages/balancer-gql/src/gql/__generated__/polygon.ts
@@ -5232,6 +5232,13 @@ export type PoolOwnerQueryVariables = Exact<{
 
 export type PoolOwnerQuery = { __typename?: 'Query', pool?: { __typename?: 'Pool', owner?: any | null } | null };
 
+export type PoolAddressQueryVariables = Exact<{
+  poolId: Scalars['ID'];
+}>;
+
+
+export type PoolAddressQuery = { __typename?: 'Query', pool?: { __typename?: 'Pool', address: any } | null };
+
 
 export const PoolsDocument = gql`
     query Pools($owner: Bytes!) {
@@ -5261,6 +5268,13 @@ export const PoolOwnerDocument = gql`
   }
 }
     `;
+export const PoolAddressDocument = gql`
+    query PoolAddress($poolId: ID!) {
+  pool(id: $poolId) {
+    address
+  }
+}
+    `;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 
@@ -5277,6 +5291,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     PoolOwner(variables: PoolOwnerQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<PoolOwnerQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<PoolOwnerQuery>(PoolOwnerDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'PoolOwner', 'query');
+    },
+    PoolAddress(variables: PoolAddressQueryVariables, requestHeaders?: Dom.RequestInit["headers"]): Promise<PoolAddressQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<PoolAddressQuery>(PoolAddressDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'PoolAddress', 'query');
     }
   };
 }
@@ -5294,6 +5311,9 @@ export function getSdkWithHooks(client: GraphQLClient, withWrapper: SdkFunctionW
     },
     usePoolOwner(variables: PoolOwnerQueryVariables, config?: SWRConfigInterface<PoolOwnerQuery, ClientError>) {
       return useSWR<PoolOwnerQuery, ClientError>(genKey<PoolOwnerQueryVariables>('PoolOwner', variables), () => sdk.PoolOwner(variables), config);
+    },
+    usePoolAddress(variables: PoolAddressQueryVariables, config?: SWRConfigInterface<PoolAddressQuery, ClientError>) {
+      return useSWR<PoolAddressQuery, ClientError>(genKey<PoolAddressQueryVariables>('PoolAddress', variables), () => sdk.PoolAddress(variables), config);
     }
   };
 }

--- a/packages/balancer-gql/src/queries/pools.ts
+++ b/packages/balancer-gql/src/queries/pools.ts
@@ -30,3 +30,11 @@ export const poolOwner = gql`
     }
   }
 `;
+
+export const poolAddress = gql`
+  query PoolAddress($poolId: ID!) {
+    pool(id: $poolId) {
+      address
+    }
+  }
+`;

--- a/packages/next-app/src/app/metadata/(components)/SearchPoolForm.tsx
+++ b/packages/next-app/src/app/metadata/(components)/SearchPoolForm.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import React from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useAccount, useNetwork } from "wagmi";
+
+import { Button } from "#/components/Button";
+import { Input } from "#/components/Input";
+import { Select, SelectItem } from "#/components/Select";
+import balancerGql, { networkIdEnumMap } from "#/lib/gql";
+
+export interface PoolMetadataAttribute {
+  poolId: string;
+  network: string;
+}
+
+const inputTypenames = [
+  { value: "1", label: "Mainnet" },
+  { value: "137", label: "Polygon" },
+  { value: "42161", label: "Arbitrum" },
+  { value: "5", label: "Goerli" },
+];
+
+export default function SearchPoolForm({ close }: { close?: () => void }) {
+  const {
+    register,
+    handleSubmit,
+    setError,
+    control,
+    watch,
+    clearErrors,
+    resetField,
+    formState: { errors },
+  } = useForm<PoolMetadataAttribute>();
+  const { push } = useRouter();
+  const { chain } = useNetwork();
+  const { isConnected } = useAccount();
+
+  const poolId = watch("poolId");
+  const network = isConnected ? chain?.id.toString() : watch("network");
+
+  const { data: poolAddress } = balancerGql(network || "1").usePoolAddress(
+    {
+      poolId,
+    },
+    { revalidateIfStale: true }
+  );
+
+  const isPool = poolAddress?.pool?.address ? true : false;
+
+  function handleSubmitForm(formData: PoolMetadataAttribute) {
+    const networkId = formData.network ?? chain?.id.toString();
+    const networkName =
+      networkIdEnumMap[networkId as keyof typeof networkIdEnumMap];
+    push(`/metadata/${networkName}/pool/${formData.poolId}`);
+
+    close?.();
+  }
+
+  React.useEffect(() => {
+    if (poolAddress && !poolAddress.pool && poolId) {
+      setError(
+        "poolId",
+        {
+          type: "notfound",
+          message: "Pool not found. Check the Pool ID and network.",
+        },
+        { shouldFocus: true }
+      );
+      return;
+    } else {
+      clearErrors("poolId");
+    }
+  }, [poolAddress]);
+
+  React.useLayoutEffect(() => {
+    resetField("poolId");
+  }, [network]);
+
+  return (
+    <form onSubmit={handleSubmit(handleSubmitForm)} className="px-2 pt-2">
+      {!isConnected && (
+        <>
+          <label className="mb-2 block text-sm text-gray-400">Network</label>
+          <div>
+            <Controller
+              control={control}
+              name={"network"}
+              defaultValue={"1"}
+              render={({ field: { onChange, value, ref } }) => (
+                <Select onValueChange={onChange} value={value} ref={ref}>
+                  {inputTypenames.map(({ value, label }) => (
+                    <SelectItem value={value}>{label}</SelectItem>
+                  ))}
+                </Select>
+              )}
+            />
+          </div>
+        </>
+      )}
+
+      <Input
+        label="pool id"
+        placeholder={"e.g 0x4467a48fjdan...0000692"}
+        {...register("poolId")}
+      />
+      <p className="text-sm text-red-400">{errors.poolId?.message}</p>
+
+      <div className="mt-4 flex items-center justify-end">
+        <Button
+          type="submit"
+          disabled={!isPool || poolId === ""}
+          className="bg-indigo-500 text-gray-50 hover:bg-indigo-400 focus-visible:outline-indigo-500 disabled:bg-gray-600 disabled:text-gray-500"
+        >
+          open pool metadata
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/packages/next-app/src/app/metadata/[network]/pool/[poolId]/(components)/PoolMetadataForm.tsx
+++ b/packages/next-app/src/app/metadata/[network]/pool/[poolId]/(components)/PoolMetadataForm.tsx
@@ -130,7 +130,7 @@ export function PoolMetadataItemForm({
       />
       <p>{errors.value?.message}</p>
 
-      <div className="flex items-center justify-end gap-3">
+      <div className="mt-4 flex items-center justify-end gap-3">
         <Dialog.Close asChild>
           <Button
             type="button"

--- a/packages/next-app/src/app/metadata/layout.tsx
+++ b/packages/next-app/src/app/metadata/layout.tsx
@@ -1,11 +1,14 @@
+import { MagnifyingGlassIcon } from "@radix-ui/react-icons";
 import type { Metadata } from "next";
 import * as React from "react";
 
 import balancerSymbol from "#/assets/balancer-symbol.svg";
+import { Dialog } from "#/components/Dialog";
 import { Footer } from "#/components/Footer";
 import { Header } from "#/components/Header";
 
 import { MetadataProvider } from "./(components)/MetadataProvider";
+import SearchPoolForm from "./(components)/SearchPoolForm";
 
 export const metadata: Metadata = {
   title: "Balancer Pool Metadata",
@@ -19,7 +22,27 @@ export default function Layout({ children }: { children: React.ReactNode }) {
         linkUrl={"/metadata"}
         title={"Pool Metadata"}
         imageSrc={balancerSymbol}
-      />
+      >
+        <Dialog title={"Search pool"} content={<SearchPoolForm />}>
+          <div className="pointer-events-auto relative rounded bg-white">
+            <button
+              type="button"
+              className="flex w-full items-center rounded-md py-1.5 pl-2 pr-3 text-sm leading-6 text-slate-400 shadow-sm ring-1 ring-slate-900/10 hover:ring-slate-300 lg:flex"
+            >
+              <MagnifyingGlassIcon
+                width="21"
+                height="21"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1}
+                className="mr-3 flex-none"
+              />
+              Search pool metadata...
+            </button>
+          </div>
+        </Dialog>
+      </Header>
       <MetadataProvider>{children}</MetadataProvider>
       <Footer
         githubLink="https://github.com/bleu-studio/balancer-pool-metadata"

--- a/packages/next-app/src/app/metadata/layout.tsx
+++ b/packages/next-app/src/app/metadata/layout.tsx
@@ -38,7 +38,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
                 strokeWidth={1}
                 className="mr-3 flex-none"
               />
-              Search pool metadata...
+              Search pool...
             </button>
           </div>
         </Dialog>

--- a/packages/next-app/src/components/Header.tsx
+++ b/packages/next-app/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { ReactNode } from "react";
 import { UrlObject } from "url";
 
 import { CustomConnectButton } from "./CustomConnectButton";
@@ -10,17 +11,19 @@ interface IHeader {
   linkUrl: UrlObject | __next_route_internal_types__.RouteImpl<string>;
   imageSrc?: string;
   title: string;
+  children?: ReactNode;
 }
 
-export function Header({ linkUrl, imageSrc, title }: IHeader) {
+export function Header({ linkUrl, imageSrc, title, children }: IHeader) {
   return (
     <div className="flex h-20 flex-wrap items-center justify-between border-b border-gray-700 bg-gray-800 p-4 text-white">
       <Link href={linkUrl} className="mr-5 flex items-center gap-3">
         {imageSrc && <Image src={imageSrc} height={50} width={50} alt="" />}
-        <h1 className="flex gap-2 text-4xl font-thin not-italic leading-8 text-gray-200">
+        <h1 className="flex gap-2 text-xl font-thin not-italic leading-8 text-gray-200">
           Balancer <p className="font-medium">{title}</p>
         </h1>
       </Link>
+      {children && children}
       <CustomConnectButton />
     </div>
   );

--- a/packages/next-app/src/components/Header.tsx
+++ b/packages/next-app/src/components/Header.tsx
@@ -23,7 +23,7 @@ export function Header({ linkUrl, imageSrc, title, children }: IHeader) {
           Balancer <p className="font-medium">{title}</p>
         </h1>
       </Link>
-      {children && children}
+      {children}
       <CustomConnectButton />
     </div>
   );

--- a/packages/next-app/src/lib/gql.ts
+++ b/packages/next-app/src/lib/gql.ts
@@ -10,7 +10,7 @@ import { GraphQLClient } from "graphql-request";
 
 export const DELEGATE_OWNER = '0xBA1BA1ba1BA1bA1bA1Ba1BA1ba1BA1bA1ba1ba1B';
 
-const networkIdEnumMap = {
+export const networkIdEnumMap = {
   "1": Network.mainnet,
   "5": Network.goerli,
   "137": Network.polygon,


### PR DESCRIPTION
[linear issue](https://linear.app/bleu-llc/issue/BAL-134/select-pool-from-left-side-if-user-connected-or-search)

<img width="700" alt="image" src="https://user-images.githubusercontent.com/53192759/229522839-2847d912-65ae-49c3-911f-61de8a849280.png">

connected wallet
<img width="450" alt="image" src="https://user-images.githubusercontent.com/53192759/229522919-ae676f0e-069a-4bf9-ad98-f2ada32c6b9e.png">

disconnected wallet
<img width="450" alt="image" src="https://user-images.githubusercontent.com/53192759/229522995-e88d6a87-7a71-44cd-8c42-d529d699441a.png">

pool not found
<img width="450" alt="image" src="https://user-images.githubusercontent.com/53192759/229523202-a491a32f-d3ea-4ddc-ac33-071bd775072e.png">
