### PR TITLE
Pedro/bal 431 handle metastable conversions inside math package

### DIFF
--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -1,2 +1,146 @@
-export * as MetaStableMath from "./metastable";
-export { ExtendedStableMath as StableMath } from "./stable";
+import { bnum, OldBigNumber, StablePool } from "@balancer-labs/sor";
+import { parseFixed } from "@ethersproject/bignumber";
+import { WeiPerEther as ONE } from "@ethersproject/constants";
+
+import * as MetaStableConversions from "./metastable";
+import { ExtendedStableMath } from "./stable";
+
+type StablePoolPairData = ReturnType<
+  typeof StablePool.prototype.parsePoolPairData
+>;
+
+interface MetaStablePoolPairData extends StablePoolPairData {
+  rateIn: OldBigNumber;
+  rateOut: OldBigNumber;
+}
+
+function numberToBigNumber(number: number, decimals = 18) {
+  return parseFixed(number.toString(), decimals);
+}
+
+function numberToOldBigNumber(number: number, decimals = 18) {
+  return bnum(number.toFixed(decimals));
+}
+
+function preparePoolPairData({
+  indexIn,
+  indexOut,
+  swapFee,
+  balances,
+  rates,
+  amp,
+}: {
+  indexIn: number;
+  indexOut: number;
+  swapFee: number;
+  balances: number[];
+  rates: number[];
+  amp: number;
+}) {
+  const allBalancesOldBn = balances.map((balance, i) =>
+    numberToOldBigNumber(balance).times(numberToBigNumber(rates[i]))
+  );
+  const allBalancesBn = balances.map((balance, i) =>
+    numberToBigNumber(balance).mul(numberToBigNumber(rates[i]))
+  );
+
+  return {
+    id: "0x",
+    address: "0x",
+    poolType: 1,
+    tokenIn: "0x",
+    tokenOut: "0x",
+    balanceIn: numberToBigNumber(balances[indexIn])
+      .mul(numberToBigNumber(rates[indexIn]))
+      .div(ONE),
+    balanceOut: numberToBigNumber(balances[indexOut])
+      .mul(numberToBigNumber(rates[indexOut]))
+      .div(ONE),
+    swapFee: numberToBigNumber(swapFee, 18),
+    rateIn: numberToBigNumber(rates[indexIn]),
+    rateOut: numberToBigNumber(rates[indexOut]),
+    allBalances: allBalancesOldBn,
+    allBalancesScaled: allBalancesBn,
+    amp: numberToBigNumber(amp, 3),
+    tokenIndexIn: indexIn,
+    tokenIndexOut: indexOut,
+    decimalsIn: 6,
+    decimalsOut: 18,
+  } as MetaStablePoolPairData;
+}
+
+function exactTokenInForTokenOut(
+  amountIn: OldBigNumber,
+  poolPairData: MetaStablePoolPairData
+) {
+  const amountInToStableMath = MetaStableConversions.amountToStableMath(
+    amountIn,
+    poolPairData.rateIn
+  );
+  const amountOutToStableMath = ExtendedStableMath._exactTokenInForTokenOut(
+    amountInToStableMath,
+    poolPairData
+  );
+  return MetaStableConversions.amountFromStableMath(
+    amountOutToStableMath,
+    poolPairData.rateOut
+  );
+}
+
+function tokenInForExactTokenOut(
+  amountOut: OldBigNumber,
+  poolPairData: MetaStablePoolPairData
+) {
+  const amountOutToStableMath = MetaStableConversions.amountToStableMath(
+    amountOut,
+    poolPairData.rateOut
+  );
+  const amountInToStableMath = ExtendedStableMath._tokenInForExactTokenOut(
+    amountOutToStableMath,
+    poolPairData
+  );
+  return MetaStableConversions.amountFromStableMath(
+    amountInToStableMath,
+    poolPairData.rateIn
+  );
+}
+
+function spotPrice(poolPairData: MetaStablePoolPairData) {
+  const spotPriceToStableMath = ExtendedStableMath._spotPrice(poolPairData);
+  return MetaStableConversions.priceFromStableMath(
+    spotPriceToStableMath,
+    poolPairData.rateIn,
+    poolPairData.rateOut
+  );
+}
+
+function tokenInForExactSpotPriceAfterSwap(
+  spotPriceAfterSwap: OldBigNumber,
+  poolPairData: MetaStablePoolPairData
+) {
+  const spotPriceAfterSwapToStableMath =
+    MetaStableConversions.priceToStableMath(
+      spotPriceAfterSwap,
+      poolPairData.rateIn,
+      poolPairData.rateOut
+    );
+  const amountInToStableMath =
+    ExtendedStableMath._tokenInForExactSpotPriceAfterSwap(
+      spotPriceAfterSwapToStableMath,
+      poolPairData
+    );
+  return MetaStableConversions.amountFromStableMath(
+    amountInToStableMath,
+    poolPairData.rateIn
+  );
+}
+
+export const MetaStableMath = {
+  numberToBigNumber,
+  numberToOldBigNumber,
+  preparePoolPairData,
+  exactTokenInForTokenOut,
+  tokenInForExactTokenOut,
+  spotPrice,
+  tokenInForExactSpotPriceAfterSwap,
+} as const;

--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -135,6 +135,27 @@ function tokenInForExactSpotPriceAfterSwap(
   );
 }
 
+function tokenOutForExactSpotPriceAfterSwap(
+  spotPriceAfterSwap: OldBigNumber,
+  poolPairData: MetaStablePoolPairData
+) {
+  const spotPriceAfterSwapToStableMath =
+    MetaStableConversions.priceToStableMath(
+      spotPriceAfterSwap,
+      poolPairData.rateIn,
+      poolPairData.rateOut
+    );
+  const amountOutToStableMath =
+    ExtendedStableMath._tokenOutForExactSpotPriceAfterSwap(
+      spotPriceAfterSwapToStableMath,
+      poolPairData
+    );
+  return MetaStableConversions.amountFromStableMath(
+    amountOutToStableMath,
+    poolPairData.rateOut
+  );
+}
+
 export const MetaStableMath = {
   numberToBigNumber,
   numberToOldBigNumber,
@@ -143,4 +164,5 @@ export const MetaStableMath = {
   tokenInForExactTokenOut,
   spotPrice,
   tokenInForExactSpotPriceAfterSwap,
+  tokenOutForExactSpotPriceAfterSwap,
 } as const;

--- a/packages/next-app/src/app/stableswapsimulator/(components)/DepthCost.tsx
+++ b/packages/next-app/src/app/stableswapsimulator/(components)/DepthCost.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { bnum } from "@balancer-labs/sor";
-import { StableMath } from "@balancer-pool-metadata/math/src";
+import { MetaStableMath } from "@balancer-pool-metadata/math/src";
 import { PlotType } from "plotly.js";
 
 import Plot, { defaultAxisLayout } from "#/components/Plot";
@@ -183,33 +183,34 @@ function calculateDepthCostAmount(
 ) {
   if (!data.swapFee || !data.ampFactor) return;
 
-  const { preparePoolPairData, indexAnalysisToken } = useStableSwap();
+  const { indexAnalysisToken } = useStableSwap();
 
   const indexIn = poolSide === "in" ? indexAnalysisToken : pairTokenIndex;
   const indexOut = poolSide === "in" ? pairTokenIndex : indexAnalysisToken;
 
-  const poolPairData = preparePoolPairData({
+  const poolPairData = MetaStableMath.preparePoolPairData({
     indexIn: indexIn,
     indexOut: indexOut,
     swapFee: data?.swapFee,
-    allBalances: data?.tokens?.map((token) => token.balance),
+    balances: data?.tokens?.map((token) => token.balance),
+    rates: data?.tokens?.map((token) => token.rate),
     amp: data?.ampFactor,
   });
 
-  const currentSpotPriceFromStableMath = StableMath._spotPrice(poolPairData);
+  const currentSpotPriceFromStableMath = MetaStableMath.spotPrice(poolPairData);
 
   const newSpotPriceToStableMath = currentSpotPriceFromStableMath.times(
     bnum(1.02)
   );
 
   if (poolSide === "in") {
-    StableMath._tokenInForExactSpotPriceAfterSwap(
+    MetaStableMath.tokenInForExactSpotPriceAfterSwap(
       newSpotPriceToStableMath,
       poolPairData
     ).toNumber();
   }
 
-  return StableMath._tokenInForExactSpotPriceAfterSwap(
+  return MetaStableMath.tokenOutForExactSpotPriceAfterSwap(
     newSpotPriceToStableMath,
     poolPairData
   ).toNumber();

--- a/packages/next-app/src/app/stableswapsimulator/(components)/StableCurve.tsx
+++ b/packages/next-app/src/app/stableswapsimulator/(components)/StableCurve.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { StableMath } from "@balancer-pool-metadata/math/src";
+import { MetaStableMath } from "@balancer-pool-metadata/math/src";
 
 import Plot from "#/components/Plot";
 import { Spinner } from "#/components/Spinner";
@@ -12,8 +12,6 @@ export default function StableCurve() {
     variantData,
     indexAnalysisToken,
     indexCurrentTabToken,
-    preparePoolPairData,
-    numberToOldBigNumber,
   } = useStableSwap();
 
   if (
@@ -37,33 +35,35 @@ export default function StableCurve() {
 
     const amountsOut = amountsIn.map((amount) => -1 * amount);
 
-    const poolPairDataIn = preparePoolPairData({
+    const poolPairDataIn = MetaStableMath.preparePoolPairData({
       indexIn,
       indexOut,
       swapFee,
-      allBalances: baselineData.tokens.map((token) => token.balance),
+      balances: baselineData.tokens.map((token) => token.balance),
+      rates: baselineData.tokens.map((token) => token.rate),
       amp,
     });
 
     const amountsTabTokenOut = amountsIn.map(
       (amount) =>
-        StableMath._exactTokenInForTokenOut(
-          numberToOldBigNumber(amount),
+        MetaStableMath.exactTokenInForTokenOut(
+          MetaStableMath.numberToOldBigNumber(amount),
           poolPairDataIn
         ).toNumber() * -1
     );
 
-    const poolPairDataOut = preparePoolPairData({
+    const poolPairDataOut = MetaStableMath.preparePoolPairData({
       indexIn: indexOut,
       indexOut: indexIn,
       swapFee,
-      allBalances: baselineData.tokens.map((token) => token.balance),
+      balances: baselineData.tokens.map((token) => token.balance),
+      rates: baselineData.tokens.map((token) => token.rate),
       amp,
     });
 
     const amountsTabTokenIn = amountsIn.map((amount) =>
-      StableMath._exactTokenInForTokenOut(
-        numberToOldBigNumber(amount),
+      MetaStableMath.exactTokenInForTokenOut(
+        MetaStableMath.numberToOldBigNumber(amount),
         poolPairDataOut
       ).toNumber()
     );

--- a/packages/next-app/src/contexts/StableSwapContext.tsx
+++ b/packages/next-app/src/contexts/StableSwapContext.tsx
@@ -1,8 +1,6 @@
 "use client";
 
-import { bnum, StablePool } from "@balancer-labs/sor";
 import { PoolQuery } from "@balancer-pool-metadata/gql/src/balancer-pools/__generated__/Ethereum";
-import { parseFixed } from "@ethersproject/bignumber";
 import { usePathname, useRouter } from "next/navigation";
 import {
   createContext,
@@ -14,10 +12,6 @@ import {
 
 import { PoolAttribute } from "#/components/SearchPoolForm";
 import { pools } from "#/lib/gql";
-
-type StablePoolPairData = ReturnType<
-  typeof StablePool.prototype.parsePoolPairData
->;
 
 export interface TokensData {
   symbol: string;
@@ -44,20 +38,6 @@ interface StableSwapContextType {
   newPoolImportedFlag: boolean;
   isGraphLoading: boolean;
   setIsGraphLoading: (value: boolean) => void;
-  preparePoolPairData: ({
-    indexIn,
-    indexOut,
-    swapFee,
-    allBalances,
-    amp,
-  }: {
-    indexIn: number;
-    indexOut: number;
-    swapFee: number;
-    allBalances: number[];
-    amp: number;
-  }) => StablePoolPairData;
-  numberToOldBigNumber: (number: number, decimals?: number) => typeof bnum;
 }
 
 export const StableSwapContext = createContext({} as StableSwapContextType);
@@ -104,52 +84,6 @@ export function StableSwapProvider({ children }: PropsWithChildren) {
     setVariantData(convertGqlToAnalysisData(poolData));
   }
 
-  function numberToBigNumber(number: number, decimals = 18) {
-    return parseFixed(number.toString(), decimals);
-  }
-
-  function numberToOldBigNumber(number: number, decimals = 18) {
-    return bnum(number.toFixed(decimals));
-  }
-
-  function preparePoolPairData({
-    indexIn,
-    indexOut,
-    swapFee,
-    allBalances,
-    amp,
-  }: {
-    indexIn: number;
-    indexOut: number;
-    swapFee: number;
-    allBalances: number[];
-    amp: number;
-  }) {
-    const allBalancesOldBn = allBalances.map((balance) =>
-      numberToOldBigNumber(balance)
-    );
-    const allBalancesBn = allBalances.map((balance) =>
-      numberToBigNumber(balance)
-    );
-    return {
-      id: "0x",
-      address: "0x",
-      poolType: 1,
-      tokenIn: "0x",
-      tokenOut: "0x",
-      balanceIn: numberToBigNumber(allBalances[indexIn]),
-      balanceOut: numberToBigNumber(allBalances[indexOut]),
-      swapFee: numberToBigNumber(swapFee, 18),
-      allBalances: allBalancesOldBn,
-      allBalancesScaled: allBalancesBn,
-      amp: numberToBigNumber(amp, 3),
-      tokenIndexIn: indexIn,
-      tokenIndexOut: indexOut,
-      decimalsIn: 6,
-      decimalsOut: 18,
-    } as StablePoolPairData;
-  }
-
   useEffect(() => {
     if (!baselineData.swapFee) {
       push("/stableswapsimulator");
@@ -182,8 +116,6 @@ export function StableSwapProvider({ children }: PropsWithChildren) {
         newPoolImportedFlag,
         isGraphLoading,
         setIsGraphLoading,
-        preparePoolPairData,
-        numberToOldBigNumber,
       }}
     >
       {children}


### PR DESCRIPTION
This PR:
- Remove math related functions from context;
- Combine MetaStable conversion with MetaStable;
- Refactor exports of stable math;
